### PR TITLE
wrapless: Add comments on protocol

### DIFF
--- a/print_config_53x5.py
+++ b/print_config_53x5.py
@@ -1,0 +1,42 @@
+from driver_53x5 import DEFAULT_CONFIG
+
+
+def get_sections(config):
+    sections = []
+
+    section_table = config[1:0x11]
+    for section_table_offt in range(0, 0x10, 2):
+        section_base = section_table[section_table_offt]
+        section_size = section_table[section_table_offt + 1]
+
+        section = config[section_base : section_base + section_size]
+        sections.append(section)
+
+    return sections
+
+
+def parse_section(section):
+    entries = []
+    for entry_offt in range(0, len(section), 4):
+        addr = int.from_bytes(section[entry_offt : entry_offt + 2], byteorder="little")
+        value = int.from_bytes(
+            section[entry_offt + 2 : entry_offt + 4], byteorder="little"
+        )
+        entries.append((addr, value))
+    return entries
+
+
+def main():
+    sections = get_sections(DEFAULT_CONFIG)
+    for section_idx, section in enumerate(sections):
+        print()
+        print(f"Section {section_idx}:")
+
+        entries = parse_section(section)
+        for entry in entries:
+            addr, value = entry
+            print(f"  {addr:x}:\t{value:x}")
+
+
+if __name__ == "__main__":
+    main()

--- a/wireshark/wrapless_goodix_message.lua
+++ b/wireshark/wrapless_goodix_message.lua
@@ -421,6 +421,7 @@ commands = {
     },
     [0xf] = { -- Correct
         category_name = "FLASH",
+
         [0] = {
             name = "Write Firmware",
             dissect_command = function(tree, buf)

--- a/wireshark/wrapless_goodix_message.lua
+++ b/wireshark/wrapless_goodix_message.lua
@@ -247,6 +247,19 @@ commands = {
             name = "Set Powerdown Scan Frequency",
             dissect_command = function(tree, buf)
                 tree:add_le(powerdown_scan_frequency, buf(0, 2))
+        [3] = { -- Correct
+            name = "Get USB PID buffer",
+            dissect_command = function(tree, buf)
+            end,
+            dissect_reply = function(tree, buf)
+                -- byte[0:0x20]: 0x20 buffer
+            end
+        },
+        [4] = { -- Correct
+            name = "Flash USB PID buffer",
+            dissect_command = function(tree, buf)
+                -- byte[0:0x20]: 0x20 buffer
+                -- byte[0x20:0x24]: 0x20 buffer mask
             end,
             dissect_reply = function(tree, buf)
                 tree:add_le(success, buf(0, 1))

--- a/wireshark/wrapless_goodix_message.lua
+++ b/wireshark/wrapless_goodix_message.lua
@@ -358,24 +358,20 @@ commands = {
 
         [0] = {
             name = "ESD Happened", -- Electro Static Discharge?
-            dissect_command = function(tree, buf)
-            end,
             dissect_reply = function(tree, buf)
-                -- irq[0,1]
+                -- byte[0:2]: IRQ
             end
         },
         [1] = {
             name = "Wake up",
-            dissect_command = function(tree, buf)
-            end,
             dissect_reply = function(tree, buf)
+                -- byte[0:2]: IRQ
             end
         },
         [2] = {
             name = "Press Power Button",
-            dissect_command = function(tree, buf)
-            end,
             dissect_reply = function(tree, buf)
+                tree:add_le(success, buf(0, 1))
             end
         },
     },

--- a/wireshark/wrapless_goodix_message.lua
+++ b/wireshark/wrapless_goodix_message.lua
@@ -259,10 +259,21 @@ commands = {
             end
         }
     },
-    [0xa] = {
+    [0xa] = { -- Correct
         category_name = "OTHER",
 
-        [1] = { -- Correct
+        [0] = {
+            name = "Set SPI prescaler",
+            dissect_command = function(tree, buf)
+                -- byte[0]: SPI clock prescaler
+                -- byte[1]: 0 -> get, 1 -> set
+            end,
+            dissect_reply = function(tree, buf)
+                tree:add_le(success, buf(0, 1))
+                -- byte[1]: SPI clock prescaler
+            end
+        },
+        [1] = {
             name = "Reset",
             dissect_command = function(tree, buf)
                 tree:add_le(reset_sensor, buf(0, 1))
@@ -271,11 +282,12 @@ commands = {
                 tree:add_le(sleep_time, buf(1, 1))
             end,
             dissect_reply = function(tree, buf)
-                tree:add_le(reset_irq_status, buf(0, 3))
+                -- byte[0]: event happened
+                -- byte[1:3]: IRQ (only if event happened)
             end
         },
-        [2] = { -- Correct
-            name = "MCU Clear Flash",
+        [2] = {
+            name = "Delete APP firmware info",
             dissect_command = function(tree, buf)
                 tree:add_le(sleep_time, buf(1, 1))
             end,
@@ -283,14 +295,15 @@ commands = {
                 tree:add_le(success, buf(0, 1))
             end
         },
-        [3] = { -- Correct
+        [3] = {
             name = "Read OTP",
             dissect_command = function(tree, buf)
             end,
             dissect_reply = function(tree, buf)
+                -- byte[0:0x20]: OTP
             end
         },
-        [4] = { -- Correct
+        [4] = {
             name = "Firmware Version",
             dissect_command = function(tree, buf)
             end,
@@ -298,12 +311,23 @@ commands = {
                 tree:add_le(version, buf())
             end
         },
-        [6] = {
-            name = "Set PC State",
+        [5] = {
+            name = "SPI send",
             dissect_command = function(tree, buf)
-                tree:add_le(base_type, buf(0, 1))
+                -- byte[0]: value to send
+                -- byte[1]: sleep time
             end,
             dissect_reply = function(tree, buf)
+            end
+        },
+        [6] = {
+            name = "Flash OTP",
+            dissect_command = function(tree, buf)
+                -- byte[0:0x20]: OTP
+                -- byte[0x20:0x24]: OTP mask
+            end,
+            dissect_reply = function(tree, buf)
+                tree:add_le(success, buf(0, 1))
             end
         },
         [7] = {
@@ -313,6 +337,7 @@ commands = {
                 tree:add_le(remote_wakeup, buf(1, 1))
             end,
             dissect_reply = function(tree, buf)
+                tree:add_le(success, buf(0, 1))
             end
         }
     },


### PR DESCRIPTION
This PR contains the result of the reversing effort on the 5395 firmware:
- It describes all the available commands within the Wireshark dissector, using comments.
- It modifies the dumper to show the OTP and USB PID flash regions.
- It adds a method to overwrite the option byte (dangerous).