### PR TITLE
preprocessor: drop hardcoded black and white levels

### DIFF
--- a/preprocessor.py
+++ b/preprocessor.py
@@ -4,6 +4,9 @@ import tool
 import argparse
 import os
 
+# TODO: implement proper coverage detection
+# Current implementation relies on non-covered pixels to be much brighter
+# than actual fingerprint image
 def get_inverse_coverage(image):
     notcovered = 0
     for pixel in image:


### PR DESCRIPTION
It appears to work pretty well with clamped black/white levels if the border is properly discarded. Otherwise black level is estimated incorrectly. For white level we need to discard pixels that are not covered.